### PR TITLE
Validate the input to `RFC3986EscapedStringWithEncoding()` 

### DIFF
--- a/AFXAuthClient/AFXAuthClient.m
+++ b/AFXAuthClient/AFXAuthClient.m
@@ -63,6 +63,9 @@ static NSString * AFEncodeBase64WithData(NSData *data)
 
 static NSString * RFC3986EscapedStringWithEncoding(NSString *string, NSStringEncoding encoding)
 {
+	// Validate the input string to ensure we dont return nil.
+	string = string ?: @"";
+	
 	// Escape per RFC 3986 standards as required by OAuth. Previously, not
 	// escaping asterisks (*) causes passwords with * to fail in
 	// Instapaper authentication


### PR DESCRIPTION
So that it does not return nil.

fixes #5
