### PR TITLE
Prevents warnings caused by AFNetworking dependency

### DIFF
--- a/AFXAuthClient.podspec
+++ b/AFXAuthClient.podspec
@@ -15,4 +15,17 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.7'
 
   s.dependency 'AFNetworking', '>= 0.9'
+  s.prefix_header_contents = <<-EOS
+  #import <Availability.h>
+
+  #if __IPHONE_OS_VERSION_MIN_REQUIRED
+    #import <SystemConfiguration/SystemConfiguration.h>
+    #import <MobileCoreServices/MobileCoreServices.h>
+    #import <Security/Security.h>
+  #else
+    #import <SystemConfiguration/SystemConfiguration.h>
+    #import <CoreServices/CoreServices.h>
+    #import <Security/Security.h>
+  #endif
+EOS
 end


### PR DESCRIPTION
Currently I'm experiencing warnings due to the lack of MobileCoreServices and SystemConfiguration in the prefix file under the new cocoapods system. This commit resolves that issue.
